### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "export"
   ],
   "description": "Converts Supervisely annotations to Cityscapes format and prepares downloadable tar archive",
-  "docker_image": "supervisely/import-export:6.73.162",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.11.8",
   "main_script": "src/main.py",
   "modal_template": "",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "export"
   ],
   "description": "Converts Supervisely annotations to Cityscapes format and prepares downloadable tar archive",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   ],
   "description": "Converts Supervisely annotations to Cityscapes format and prepares downloadable tar archive",
   "docker_image": "supervisely/import-export:6.73.564",
-  "instance_version": "6.11.8",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "",
   "modal_template_state": {},

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "export"
   ],
   "description": "Converts Supervisely annotations to Cityscapes format and prepares downloadable tar archive",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.162
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
